### PR TITLE
Enhance(cd)/integrate ansible to setup ec2 instances

### DIFF
--- a/.github/workflows/setup_machines.yml
+++ b/.github/workflows/setup_machines.yml
@@ -29,19 +29,112 @@ jobs:
               id: parse-outputs
               run: |
                 # Use jq to extract IPs from within the parsed outputs
-                PUBLIC_IP=$(jq -r '.[] | select(.name == "apiGw_instance_details") | .value.public_ip' terraform-outputs.json)
-                PRIVATE_IP=$(jq -r '.[] | select(.name == "eureka_instance_details") | .value.private_ip' terraform-outputs.json)
+                API-GW_IP=$(jq -r '.[] | select(.name == "apiGw_instance_details") | .value.public_ip' terraform-outputs.json)
+                EUREKA_SERVER_IP=$(jq -r '.[] | select(.name == "eureka_instance_details") | .value.private_ip' terraform-outputs.json)
+
+                # add masks to hide the ips in the output
+                echo "::add-mask::$API_GW_IP"
+                echo "::add-mask::$EUREKA_SERVER_IP"
+    
+                # Save IPs to environment variables
+                echo "API_GW_IP=$API_GW_IP" >> $GITHUB_OUTPUT
+                echo "EUREKA_SERVER_IP=$EUREKA_SERVER_IP" >> $GITHUB_OUTPUT
                 
                 # read the inventory template then store it within INVENTORY_TEMPLATE variable
                 INVENTORY_TEMPLATE=$(cat src/ansible/inventory.tpl)
                 
                 # Replace placeholders within the inventory
-                INVENTORY=$(echo "$INVENTORY_TEMPLATE" | sed "s/PUBLIC_IP_PLACEHOLDER/$PUBLIC_IP/g" | sed "s/PRIVATE_IP_PLACEHOLDER/$PRIVATE_IP/g")
+                INVENTORY=$(echo "$INVENTORY_TEMPLATE" | sed "s/API-GW_IP_PLACEHOLDER/$API-GW_IP/g" | sed "s/EUREKA_IP_PLACEHOLDER/$EUREKA_SERVER_IP/g") 
                 
                 # Write the final inventory file
                 echo "$INVENTORY" > ansible/inventory
+
+             # Upload the inventory as an artifact
+            - name: Upload inventory artifact
+              uses: actions/upload-artifact@v4
+              with:
+                name: ansible-inventory
+                path: ansible/inventory
             
             - name: Run Ansible Playbook
               run: ansible-playbook -i ansible/inventory src/ansible/setup_docker.yml
+              env:
+                ANSIBLE_HOST_KEY_CHECKING: False
+        outputs:
+          apiGwIp: ${{ steps.parse-outputs.outputs.API_GW_IP }}
+          eurekaIp: ${{ steps.parse-outputs.outputs.EUREKA_SERVER_IP }}  
+    
+    run-eureka:
+        needs: process-terraform-outputs
+        runs-on: ubuntu-latest
+
+        steps:
+
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Download env template
+              run: |
+                wget https://raw.githubusercontent.com/Form-iit/service-discovery/refs/heads/main/docker-compose.template.env -O .env.template
+              
+            - name: Prepare environment file
+              run: |
+                cp .env.template .env
+                sed -i "s/placeholder_server_port/${{ secrets.EUREKA_SERVER_PORT }}/g" .env
+                sed -i "s/placeholder_ip_address/${{ needs.process-terraform-outputs.outputs.eurekaIp }}/g" .env
+                sed -i "s/placeholder_serviceurl/http:\/\/${{ needs.process-terraform-outputs.outputs.eurekaIp }}:${{ secrets.EUREKA_SERVER_PORT }}\/eureka/g" .env
+                sed -i "s/placeholder_username/${{ secrets.EUREKA_ADMIN_USERNAME }}/g" .env
+                sed -i "s/placeholder_password/${{ secrets.EUREKA_ADMIN_PASSWORD }}/g" .env
+
+            - name: Set up Python
+              uses: actions/setup-python@v4
+            
+            - name: Set up Ansible
+              run: |
+                pip install ansible
+                ansible-galaxy collection install community.docker
+                ansible-galaxy collection install community.general
+
+            # Download the inventory artifact
+            - name: Download inventory artifact
+              uses: actions/download-artifact@v4
+              with:
+                name: ansible-inventory
+            
+            - name: Run Ansible Playbook
+              id: run-playbook
+              run: ansible-playbook -i ansible/inventory src/ansible/playbooks/run_eureka.yml
+              env:
+                ANSIBLE_HOST_KEY_CHECKING: False
+
+        outputs:
+          eureka-status: ${{ steps.run-playbook.outcome }}
+    
+    run-api-gateway:
+        needs: run-eureka
+        if: ${{ needs.run-eureka.outputs.eureka-status == 'success' }}
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            
+            - name: Set up Python
+              uses: actions/setup-python@v4
+            
+            - name: Set up Ansible
+              run: |
+                pip install ansible
+                ansible-galaxy collection install community.docker
+                ansible-galaxy collection install community.general
+
+            # Download the inventory artifact
+            - name: Download inventory artifact
+              uses: actions/download-artifact@v4
+              with:
+                name: ansible-inventory
+
+            - name: Run API Gateway Ansible Playbook
+              run: ansible-playbook -i ansible/inventory src/ansible/playbooks/run_apiGW.yml
               env:
                 ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/setup_machines.yml
+++ b/.github/workflows/setup_machines.yml
@@ -1,0 +1,47 @@
+name: "Ansible: setup docker on machines"
+
+on:
+    workflow_dispatch: 
+    workflow_run:
+        workflows:
+            - Infrastructure Deployment
+        types:
+            - completed
+
+jobs:
+    process-terraform-outputs:
+        if: github.event.workflow_run.conclusion == 'success'
+        runs-on: ubuntu-latest
+
+        steps:
+            # Checkout to the repo
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            
+            # Download the artifact holding terraform output
+            - name: Download terraform outputs artifact
+              uses: actions/download-artifact@v4
+              with:
+                name: terraform-outputs
+            
+            # Parse the json outputs
+            - name: Parse Terraform Outputs and Create Inventory
+              id: parse-outputs
+              run: |
+                # Use jq to extract IPs from within the parsed outputs
+                PUBLIC_IP=$(jq -r '.[] | select(.name == "apiGw_instance_details") | .value.public_ip' terraform-outputs.json)
+                PRIVATE_IP=$(jq -r '.[] | select(.name == "eureka_instance_details") | .value.private_ip' terraform-outputs.json)
+                
+                # read the inventory template then store it within INVENTORY_TEMPLATE variable
+                INVENTORY_TEMPLATE=$(cat src/ansible/inventory.tpl)
+                
+                # Replace placeholders within the inventory
+                INVENTORY=$(echo "$INVENTORY_TEMPLATE" | sed "s/PUBLIC_IP_PLACEHOLDER/$PUBLIC_IP/g" | sed "s/PRIVATE_IP_PLACEHOLDER/$PRIVATE_IP/g")
+                
+                # Write the final inventory file
+                echo "$INVENTORY" > ansible/inventory
+            
+            - name: Run Ansible Playbook
+              run: ansible-playbook -i ansible/inventory src/ansible/setup_docker.yml
+              env:
+                ANSIBLE_HOST_KEY_CHECKING: False

--- a/src/ansible/inventory.tpl
+++ b/src/ansible/inventory.tpl
@@ -1,0 +1,5 @@
+[api_gw]
+API-GW_IP_PLACEHOLDER
+
+[eureka_server]
+EUREKA_IP_PLACEHOLDER ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -i ~/.ssh/id_rsa API-GW_IP_PLACEHOLDER"'

--- a/src/ansible/playbooks/run_apiGW.yml
+++ b/src/ansible/playbooks/run_apiGW.yml
@@ -1,0 +1,15 @@
+- name: Run Api Gateway's docker compose
+  hosts: api_gw
+  become: true
+  become_user: ec2-user
+
+  tasks:
+    - name: Ensure apiGw directory exists
+      file:
+        path: "~/apiGw"
+        state: directory
+    
+    - name: Create a file and write success in it
+      shell: echo "success" > ~/apiGw/file.txt
+      args:
+        creates: ~/apiGw/file.txt

--- a/src/ansible/playbooks/run_eureka.yml
+++ b/src/ansible/playbooks/run_eureka.yml
@@ -1,0 +1,71 @@
+- name: Run Eureka server's docker compose
+  hosts: eureka_server
+  become: true
+  become_user: ec2-user
+
+  tasks:
+    - name: Ensure eureka directory exists
+      file:
+        path: "~/eureka"
+        state: directory
+
+    - name: Copy .env file to target machine
+      copy:
+        src: .env
+        dest: "~/eureka/.env"
+
+    - name: Pull Docker image from Docker Hub
+      docker_image:
+        name: "diamobachar/service-discovery:latest"
+        source: pull
+
+    - name: Fetch Docker Compose file from GitHub
+      get_url:
+        url: "https://raw.githubusercontent.com/Form-iit/service-discovery/main/docker-compose.yml"
+        dest: "~/eureka/docker-compose.yml"
+
+    - name: Start Docker Compose
+      community.docker.docker_compose:
+        project_src: "~/eureka"
+        env_file: "~/eureka/.env"
+        pull: yes
+        state: present
+    
+    - name: Load Eureka credentials
+      block:
+        - name: Read Eureka username
+          lineinfile:
+            path: ~/eureka/.env
+            regexp: '^EUREKA_ADMIN_USERNAME='
+            state: present
+          register: username_line
+
+        - name: Read Eureka password
+          lineinfile:
+            path: ~/eureka/.env
+            regexp: '^EUREKA_ADMIN_PASSWORD='
+            state: present
+          register: password_line
+
+        - name: Set credentials
+          set_fact:
+            credentials:
+              username: "{{ username_line.line.split('=')[1] }}"
+              password: "{{ password_line.line.split('=')[1] }}"
+
+    - name: Wait for Eureka service to be ready
+      uri:
+        url: "http://localhost:8761/actuator/health"
+        status_code: 200
+        user: "{{ eureka_credentials.username }}"
+        password: "{{ eureka_credentials.password }}"
+        force_basic_auth: yes
+      register: health_check
+      retries: 10
+      delay: 5
+      until: 
+        - health_check.status == 200
+        - (health_check.json.status | default('')) == 'UP'
+      failed_when:
+        - health_check.status != 200
+        - (health_check.json.status | default('')) != 'UP' 

--- a/src/ansible/playbooks/setup_docker.yml
+++ b/src/ansible/playbooks/setup_docker.yml
@@ -1,0 +1,59 @@
+- hosts: api_gw:eureka_server
+  become: yes
+  become_user: ec2-user
+  tasks:
+    - name: Update yum packages
+      yum:
+        name: "*"
+        latest: true
+
+    - name: Install docker
+      yum:
+        name: docker
+        state: present
+        update_cache: true
+    
+    - name: Start docker
+      service:
+        name: docker
+        state: started
+        enabled: true
+    
+    - name: Add user to docker group
+      command:  usermod -a -G docker ec2-user
+
+    - name: Force Ansible to reconnect #(equivalent to session logout/login)
+      meta: reset_connection
+
+    - name: Check Docker version
+      command: docker --version
+      register: docker_version_output
+
+    - name: Output Docker version
+      debug:
+        msg: "Docker version: {{ docker_version_output.stdout }}"
+
+    - name: Check Docker Compose version
+      command: docker-compose --version
+      register: docker_compose_version_output
+
+    - name: Output Docker Compose version
+      debug:
+        msg: "Docker Compose version: {{ docker_compose_version_output.stdout }}"
+
+    
+    - name: "Download Docker Compose"
+      get_url:
+        url: "https://github.com/docker/compose/releases/latest/download/docker-compose-{{ ansible_system | lower }}-{{ ansible_architecture }}"
+        dest: /usr/local/bin/docker-compose
+        mode: '0755'
+
+    - name: Check Docker Compose version
+      command: docker-compose --version
+      register: docker_compose_version_output
+
+    - name: Output Docker Compose version
+      debug:
+        msg: "Docker Compose version: {{ docker_compose_version_output.stdout }}"
+
+

--- a/src/terraform/NATInstance.tf
+++ b/src/terraform/NATInstance.tf
@@ -36,12 +36,3 @@ resource "aws_instance" "nat_instance" {
     Name = "NAT-Instance"
   }
 }
-
-output "nat_instance_id" {
-  value = aws_instance.nat_instance.id
-}
-
-
-output "nat_instance_ip" {
-  value     = aws_instance.nat_instance.public_ip
-}

--- a/src/terraform/eureka_EC2_instance.tf
+++ b/src/terraform/eureka_EC2_instance.tf
@@ -18,8 +18,16 @@ resource "aws_instance" "eureka_EC2" {
 
   subnet_id                   = aws_subnet.private_subnet.id
   associate_public_ip_address = false
+
+  user_data = <<-EOF
+            #!/bin/bash
+            hostnamectl set-hostname eureka-server
+            EOF
 }
 
-output "eureka_instance_ip" {
-  value = aws_instance.eureka_EC2.private_ip
+output "eureka_instance_details" {
+  value = {
+    private_ip = aws_instance.eureka_EC2.private_ip
+    hostname  = "eureka-server"
+  }
 }

--- a/src/terraform/privateSubnet.tf
+++ b/src/terraform/privateSubnet.tf
@@ -29,8 +29,3 @@ resource "aws_route_table_association" "private_subnet_assocTo_route_table" {
   subnet_id      = aws_subnet.private_subnet.id
   route_table_id = aws_route_table.private_route_table.id
 }
-
-
-output "private_subnet_cidr_block" {
-  value = aws_subnet.private_subnet.cidr_block
-}

--- a/src/terraform/publicSubnet.tf
+++ b/src/terraform/publicSubnet.tf
@@ -29,7 +29,3 @@ resource "aws_route_table_association" "public_subnet_assocTo_route_table" {
   subnet_id      = aws_subnet.public_subnet.id
   route_table_id = aws_route_table.public_route_table.id
 }
-
-output "public_subnet_cidr_block" {
-  value = aws_subnet.public_subnet.cidr_block
-}

--- a/src/terraform/vpc.tf
+++ b/src/terraform/vpc.tf
@@ -6,12 +6,3 @@ resource "aws_vpc" "Formiit-VPC" {
     Name = "Formiit-VPC"
   }
 }
-
-output "vpc_id" {
-  value = aws_vpc.Formiit-VPC.id
-}
-
-
-output "vpc_cidr_block" {
-  value = aws_vpc.Formiit-VPC.cidr_block
-}


### PR DESCRIPTION
Changes:

1. Ansible:
- Made an Inventory template for hosts (`eureka ` and the ` api gateway`)
- Made a playbook that setups docker and docker compose within the hosts
- Made a playbook that pulls the docker image, sets the env vars and runs the docker compose within `eureka `host
- Made a playbook that pulls the docker image, sets the env vars and runs the docker compose within `api gateway` host
2. Actions:
Extended the pipeline functionality so that it fills the inventory from the `terraform output`,  fills up `env variables` from **secrets** and runs the playbooks.